### PR TITLE
Add Telegram export and analyzer skills

### DIFF
--- a/.codex/skills/telegram-analyzer/SKILL.md
+++ b/.codex/skills/telegram-analyzer/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: telegram-analyzer
+description: Analyze exported Telegram message datasets (JSONL/Markdown/text) for themes, sentiment signals, activity patterns, and action items. Use after message export when a user asks for summaries, trend analysis, topic extraction, conversation health checks, or behavioral insights.
+---
+
+# Telegram Analyzer
+
+Analyze Telegram exports and produce structured insights with reproducible steps.
+
+## Input expectations
+
+Preferred input: JSONL produced by `telegram-export` with one record per line.
+
+Also acceptable:
+- plain text transcripts
+- markdown chat dumps
+
+If input is not normalized, first convert it to a table with columns:
+`datetime_utc`, `sender`, `text`.
+
+## Analysis workflow
+
+1. **Load and profile**
+   - count messages
+   - date range
+   - top senders
+   - empty/system message proportion
+
+2. **Extract themes**
+   - identify recurring topics from noun phrases/keywords
+   - group into 3-10 high-level themes
+   - attach representative message snippets (short quotes)
+
+3. **Sentiment and tone scan**
+   - classify message-level polarity (positive/neutral/negative)
+   - aggregate by sender and by week
+   - flag sharp sentiment shifts
+
+4. **Actionability report**
+   - detect questions, decisions, TODO-like language
+   - compile open items and likely owners
+
+5. **Return concise deliverables**
+   - executive summary
+   - key metrics table
+   - top themes
+   - risks/opportunities
+   - suggested follow-up prompts
+
+## Optional scripted analysis
+
+Use `scripts/analyze_telegram_jsonl.py` for a quick baseline report before deeper LLM interpretation.
+
+```bash
+python scripts/analyze_telegram_jsonl.py --input data/telegram/messages.jsonl
+```
+
+## Quality bar
+
+- Always state the analyzed date range.
+- Separate observed facts from interpretation.
+- If sample is small (<100 messages), state low-confidence caveat.

--- a/.codex/skills/telegram-analyzer/agents/openai.yaml
+++ b/.codex/skills/telegram-analyzer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Telegram Analyzer"
+  short_description: "Analyze Telegram messages for themes and sentiment."
+  default_prompt: "Analyze exported Telegram messages and provide insights."

--- a/.codex/skills/telegram-analyzer/references/report-template.md
+++ b/.codex/skills/telegram-analyzer/references/report-template.md
@@ -1,0 +1,38 @@
+# Telegram Analysis Report Template
+
+## Executive summary
+- One paragraph summary of what happened in the conversation.
+
+## Scope
+- Date range:
+- Total messages:
+- Participants:
+
+## Metrics
+- Messages/day:
+- Top senders:
+- Question count:
+- Action-item count:
+
+## Themes
+1. Theme name
+   - Evidence snippets
+   - Why this matters
+
+## Sentiment and tone
+- Overall:
+- By sender:
+- Notable shifts:
+
+## Decisions and action items
+- Decision log:
+- Open tasks:
+- Suggested owners:
+
+## Risks and opportunities
+- Risk:
+- Opportunity:
+
+## Follow-up prompts
+- Prompt 1
+- Prompt 2

--- a/.codex/skills/telegram-analyzer/scripts/analyze_telegram_jsonl.py
+++ b/.codex/skills/telegram-analyzer/scripts/analyze_telegram_jsonl.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Quick baseline analytics for Telegram JSONL exports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze Telegram JSONL export.")
+    parser.add_argument("--input", required=True, help="Path to JSONL export file.")
+    parser.add_argument("--top-senders", type=int, default=10)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    path = Path(args.input)
+
+    total = 0
+    senders: Counter[str] = Counter()
+    day_counts: Counter[str] = Counter()
+    non_empty = 0
+
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            total += 1
+
+            sender = row.get("sender_name") or str(row.get("sender_id") or "unknown")
+            senders[sender] += 1
+
+            dt = row.get("datetime_utc")
+            if dt:
+                day = datetime.fromisoformat(dt).date().isoformat()
+                day_counts[day] += 1
+
+            if (row.get("text") or "").strip():
+                non_empty += 1
+
+    print(f"Total messages: {total}")
+    print(f"Non-empty text messages: {non_empty}")
+
+    if day_counts:
+        print(f"Date range: {min(day_counts)} to {max(day_counts)}")
+
+    print("Top senders:")
+    for sender, count in senders.most_common(args.top_senders):
+        print(f"  - {sender}: {count}")
+
+    print("Top days by volume:")
+    for day, count in day_counts.most_common(10):
+        print(f"  - {day}: {count}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/telegram-export/SKILL.md
+++ b/.codex/skills/telegram-export/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: telegram-export
+description: Export Telegram messages from personal chats, groups, or channels into local JSONL/Markdown files using Telegram API credentials. Use when a user asks to retrieve, archive, or prepare Telegram message history for downstream processing, analytics, summarization, compliance review, or another skill.
+---
+
+# Telegram Export
+
+Export Telegram message history in a repeatable, analysis-friendly format.
+
+## Quick Start
+
+1. Ensure API credentials are available as environment variables:
+   - `TELEGRAM_API_ID`
+   - `TELEGRAM_API_HASH`
+2. Install dependency: `pip install telethon`
+3. Run the exporter script:
+
+```bash
+python scripts/export_telegram_messages.py \
+  --chat "@channel_or_username" \
+  --limit 2000 \
+  --out data/telegram/messages.jsonl
+```
+
+4. Optional: also generate Markdown for easier reading:
+
+```bash
+python scripts/export_telegram_messages.py \
+  --chat "@channel_or_username" \
+  --limit 1000 \
+  --out data/telegram/messages.jsonl \
+  --markdown-out data/telegram/messages.md
+```
+
+## Workflow
+
+### 1) Resolve target chat
+
+Accept any of:
+- username (`@my_group`)
+- numeric chat id (`-1001234567890`)
+- exact title (if user provides it)
+
+If resolution is ambiguous, list recent dialogs with `--list-dialogs` and ask the user which chat to export.
+
+### 2) Export normalized records
+
+Write one JSON object per line with stable fields:
+- `chat`
+- `message_id`
+- `datetime_utc`
+- `sender_id`
+- `sender_name`
+- `text`
+- `reply_to_message_id`
+- `views`
+- `forwards`
+
+Prefer UTC timestamps and preserve original text exactly.
+
+### 3) Verify output quality
+
+Run a lightweight sanity check:
+- confirm file exists and is non-empty
+- inspect first/last records
+- confirm date ordering is descending (Telegram default) unless user requests ascending
+
+## Output contract
+
+Default output is JSONL, suitable for analysis pipelines and LLM summarization.
+
+When `--markdown-out` is provided, generate a readable document grouped by day.
+
+## Notes
+
+- First run may require interactive login/2FA in terminal.
+- Session files are created locally by Telethon; avoid committing them.
+- Respect privacy and legal constraints before exporting private chats.

--- a/.codex/skills/telegram-export/agents/openai.yaml
+++ b/.codex/skills/telegram-export/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Telegram Export"
+  short_description: "Export Telegram messages for analysis."
+  default_prompt: "Export messages from a Telegram chat and save them for analysis."

--- a/.codex/skills/telegram-export/references/schema.md
+++ b/.codex/skills/telegram-export/references/schema.md
@@ -1,0 +1,22 @@
+# Telegram Export JSONL Schema
+
+Each line in the JSONL output is one message record.
+
+```json
+{
+  "chat": "@example",
+  "message_id": 123,
+  "datetime_utc": "2026-04-19T12:34:56+00:00",
+  "sender_id": 987654321,
+  "sender_name": "Alice",
+  "text": "message body",
+  "reply_to_message_id": 120,
+  "views": 42,
+  "forwards": 3
+}
+```
+
+Guidelines:
+- Keep UTC timestamps.
+- Keep one message per JSON line.
+- Preserve text exactly; do not pre-clean unless user requests.

--- a/.codex/skills/telegram-export/scripts/export_telegram_messages.py
+++ b/.codex/skills/telegram-export/scripts/export_telegram_messages.py
@@ -41,7 +41,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Export Telegram messages to JSONL.")
     parser.add_argument("--chat", help="Chat username/title/id to export.")
     parser.add_argument("--limit", type=int, default=1000, help="Max messages to export.")
-    parser.add_argument("--out", required=True, help="Output JSONL path.")
+    parser.add_argument("--out", help="Output JSONL path.")
     parser.add_argument("--markdown-out", help="Optional Markdown output path.")
     parser.add_argument("--session", default="telegram-export", help="Telethon session name.")
     parser.add_argument(
@@ -115,6 +115,8 @@ async def _run(args: argparse.Namespace) -> int:
 
         if not args.chat:
             raise RuntimeError("--chat is required unless --list-dialogs is set.")
+        if not args.out:
+            raise RuntimeError("--out is required unless --list-dialogs is set.")
 
         records = await _export_messages(client, args.chat, args.limit)
         _write_jsonl(Path(args.out), records)

--- a/.codex/skills/telegram-export/scripts/export_telegram_messages.py
+++ b/.codex/skills/telegram-export/scripts/export_telegram_messages.py
@@ -8,7 +8,7 @@ import asyncio
 import json
 import os
 from dataclasses import dataclass
-from datetime import timezone
+from datetime import UTC
 from pathlib import Path
 
 from telethon import TelegramClient
@@ -62,7 +62,7 @@ async def _export_messages(client: TelegramClient, chat: str, limit: int) -> lis
     records: list[ExportRecord] = []
 
     async for message in client.iter_messages(entity, limit=limit):
-        dt = message.date.astimezone(timezone.utc).isoformat() if message.date else None
+        dt = message.date.astimezone(UTC).isoformat() if message.date else None
         sender = await message.get_sender() if message.sender_id else None
         sender_name = getattr(sender, "first_name", None) or getattr(sender, "title", None)
 

--- a/.codex/skills/telegram-export/scripts/export_telegram_messages.py
+++ b/.codex/skills/telegram-export/scripts/export_telegram_messages.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Export Telegram messages to JSONL (and optional Markdown) using Telethon."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from dataclasses import dataclass
+from datetime import timezone
+from pathlib import Path
+
+from telethon import TelegramClient
+
+
+@dataclass
+class ExportRecord:
+    chat: str
+    message_id: int
+    datetime_utc: str | None
+    sender_id: int | None
+    sender_name: str | None
+    text: str
+    reply_to_message_id: int | None
+    views: int | None
+    forwards: int | None
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__, ensure_ascii=False)
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Export Telegram messages to JSONL.")
+    parser.add_argument("--chat", help="Chat username/title/id to export.")
+    parser.add_argument("--limit", type=int, default=1000, help="Max messages to export.")
+    parser.add_argument("--out", required=True, help="Output JSONL path.")
+    parser.add_argument("--markdown-out", help="Optional Markdown output path.")
+    parser.add_argument("--session", default="telegram-export", help="Telethon session name.")
+    parser.add_argument(
+        "--list-dialogs",
+        action="store_true",
+        help="List recent dialogs and exit (ignores --chat).",
+    )
+    return parser
+
+
+async def _list_dialogs(client: TelegramClient) -> None:
+    async for dialog in client.iter_dialogs(limit=100):
+        print(f"{dialog.id}\t{dialog.name}")
+
+
+async def _export_messages(client: TelegramClient, chat: str, limit: int) -> list[ExportRecord]:
+    entity = await client.get_entity(chat)
+    records: list[ExportRecord] = []
+
+    async for message in client.iter_messages(entity, limit=limit):
+        dt = message.date.astimezone(timezone.utc).isoformat() if message.date else None
+        sender = await message.get_sender() if message.sender_id else None
+        sender_name = getattr(sender, "first_name", None) or getattr(sender, "title", None)
+
+        records.append(
+            ExportRecord(
+                chat=str(chat),
+                message_id=message.id,
+                datetime_utc=dt,
+                sender_id=message.sender_id,
+                sender_name=sender_name,
+                text=message.message or "",
+                reply_to_message_id=message.reply_to_msg_id,
+                views=message.views,
+                forwards=message.forwards,
+            )
+        )
+
+    return records
+
+
+def _write_jsonl(path: Path, records: list[ExportRecord]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(record.to_json() + "\n")
+
+
+def _write_markdown(path: Path, records: list[ExportRecord]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write("# Telegram Export\n\n")
+        for record in records:
+            timestamp = record.datetime_utc or "unknown-time"
+            sender = record.sender_name or str(record.sender_id) or "unknown-sender"
+            text = record.text.replace("\n", " ").strip()
+            handle.write(f"- **{timestamp}** · **{sender}** · {text}\n")
+
+
+async def _run(args: argparse.Namespace) -> int:
+    api_id = int(_require_env("TELEGRAM_API_ID"))
+    api_hash = _require_env("TELEGRAM_API_HASH")
+
+    client = TelegramClient(args.session, api_id, api_hash)
+    await client.start()
+
+    try:
+        if args.list_dialogs:
+            await _list_dialogs(client)
+            return 0
+
+        if not args.chat:
+            raise RuntimeError("--chat is required unless --list-dialogs is set.")
+
+        records = await _export_messages(client, args.chat, args.limit)
+        _write_jsonl(Path(args.out), records)
+
+        if args.markdown_out:
+            _write_markdown(Path(args.markdown_out), records)
+
+        print(f"Exported {len(records)} messages to {args.out}")
+        if args.markdown_out:
+            print(f"Wrote markdown output to {args.markdown_out}")
+
+    finally:
+        await client.disconnect()
+
+    return 0
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a repeatable way to export Telegram chats into analysis-ready formats and a companion skill to analyze those exports for themes, sentiment, and action items.

### Description

- Add a `telegram-export` skill with `SKILL.md`, `agents/openai.yaml`, `references/schema.md`, and an executable `scripts/export_telegram_messages.py` that uses `Telethon` and environment variables `TELEGRAM_API_ID`/`TELEGRAM_API_HASH` to list dialogs and export messages to JSONL (optional Markdown) with a stable schema.
- Add a `telegram-analyzer` skill with `SKILL.md`, `agents/openai.yaml`, `references/report-template.md`, and `scripts/analyze_telegram_jsonl.py` that produces baseline metrics (counts, date range, top senders, per-day volumes) and a structured analysis workflow for downstream LLM interpretation.
- Export contract and report template files document the expected JSONL schema and report structure for consistent downstream processing.

### Testing

- Ran Python byte-compile check with `python -m py_compile .codex/skills/telegram-export/scripts/export_telegram_messages.py .codex/skills/telegram-analyzer/scripts/analyze_telegram_jsonl.py`, which succeeded.
- Executed the analyzer on a small sample with `python .codex/skills/telegram-analyzer/scripts/analyze_telegram_jsonl.py --input /tmp/tg_sample.jsonl`, which produced expected summary output.
- Attempted the skill validator `scripts/quick_validate.py` but it failed in this environment due to missing `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5088b083483209cd0751727236224)