### PR TITLE
Re-enable two-sided grid ladders; add daily loss circuit breaker

### DIFF
--- a/consumers/autotrade_consumer.py
+++ b/consumers/autotrade_consumer.py
@@ -3,19 +3,23 @@ from datetime import UTC, datetime
 from typing import Any
 
 from pybinbot import (
+    AutotradeSettingsSchema,
     BinbotApi,
     BinbotErrors,
     BotBase,
+    BotModel,
     ExchangeId,
     GridDeploymentRequest,
     KucoinFutures,
     MarketType,
+    Position,
     SignalsConsumer,
+    Status,
     SymbolModel,
-    round_numbers,
-    AutotradeSettingsSchema,
     TestAutotradeSettingsSchema,
+    round_numbers,
 )
+
 from market_regime.grid_only_policy import GridOnlyPolicy
 from shared.autotrade import Autotrade
 from shared.config import Config
@@ -31,6 +35,14 @@ class AutotradeConsumer:
             "liquidation_sweep_pump",
         }
     )
+    # Circuit breaker: stop opening new real bots/ladders once today's
+    # estimated realized PnL (UTC calendar day) drops to this quote-currency
+    # amount or below. Expressed in absolute quote terms rather than a % of
+    # account balance because "available balance" swings with how much is
+    # currently locked in open positions and isn't a stable denominator.
+    # Default reflects roughly -1.5% of the current ~10 USDT futures pool —
+    # revisit if the deployable capital base changes materially.
+    DAILY_LOSS_LIMIT_QUOTE = -0.15
 
     def __init__(
         self,
@@ -48,6 +60,7 @@ class AutotradeConsumer:
         self.active_test_bots: list = active_test_bots
         self.grid_ladder_attempts: dict[tuple[str, str, str, str], float] = {}
         self.grid_only_policy = GridOnlyPolicy.disabled("not_evaluated")
+        self._futures_multiplier_cache: dict[str, float] = {}
         # Because market domination analysis 40 weight from binance endpoints
         self.btc_change_perc = 0
         self.volatility = 0
@@ -207,6 +220,93 @@ class AutotradeConsumer:
 
         return False
 
+    def _futures_contract_multiplier(self, symbol: str) -> float | None:
+        """KuCoin futures order fills record `filled_size` as a contract
+        count (see binbot's futures_deal.py), not a base-asset quantity —
+        it must be scaled by the exchange's per-symbol contract multiplier
+        to get a real quote-currency PnL, exactly like grid ladders already
+        do in binbot's lifecycle.py `_realized_pnl`. Multiplier is rarely 1
+        (e.g. XBTUSDTM=0.001, ETHUSDTM=0.01) so skipping this silently
+        misstates PnL by orders of magnitude for most symbols. Cached per
+        symbol since it's static exchange metadata. Returns None on lookup
+        failure so the caller can exclude the bot rather than guess.
+        """
+        if symbol in self._futures_multiplier_cache:
+            return self._futures_multiplier_cache[symbol]
+        try:
+            info = self.kucoin_futures_api.get_symbol_info(symbol)
+            multiplier = float(info.multiplier or 1.0)
+        except Exception:
+            logging.exception(
+                "Failed to fetch futures contract multiplier for %s; "
+                "excluding this bot from today's estimated realized PnL",
+                symbol,
+            )
+            return None
+        self._futures_multiplier_cache[symbol] = multiplier
+        return multiplier
+
+    def _bot_realized_pnl_quote(self, bot: BotModel) -> float:
+        """Estimate a closed bot's realized PnL in quote currency."""
+        deal = bot.deal
+        if not deal.opening_price or not deal.closing_price or not deal.opening_qty:
+            return 0.0
+        if str(bot.market_type) == MarketType.FUTURES.value:
+            multiplier = self._futures_contract_multiplier(bot.pair)
+            if multiplier is None:
+                return 0.0
+        else:
+            # Spot/margin qty is already base-asset-denominated.
+            multiplier = 1.0
+        direction = 1.0 if str(bot.position) == Position.long.value else -1.0
+        gross = (
+            (float(deal.closing_price) - float(deal.opening_price))
+            * float(deal.opening_qty)
+            * multiplier
+            * direction
+        )
+        return (
+            gross
+            - float(deal.total_commissions or 0)
+            - float(deal.total_interests or 0)
+        )
+
+    def estimated_daily_realized_pnl(self, collection_name: str = "bots") -> float:
+        """Sum estimated realized PnL of bots closed since UTC midnight today."""
+        now = datetime.now(UTC)
+        start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        start_date = int(start_of_day.timestamp() * 1000)
+        end_date = int(now.timestamp() * 1000)
+        closed_today = self.binbot_api.get_bots_by_status(
+            start_date=start_date,
+            end_date=end_date,
+            collection_name=collection_name,
+            status=Status.completed,
+        )
+        return sum(self._bot_realized_pnl_quote(bot) for bot in closed_today)
+
+    def daily_loss_limit_reached(self) -> bool:
+        """Circuit breaker: block new real autotrade opens (bots and grid
+        ladders alike) once today's estimated realized PnL breaches
+        DAILY_LOSS_LIMIT_QUOTE. Resets naturally at UTC midnight. Does not
+        gate paper trading, which risks no real capital.
+
+        Deliberately scoped to the `bots` collection only — grid ladders
+        are treated as a separately-risk-managed pool (bounded margin per
+        ladder, single-active-side guard, stale-ladder panic close) and are
+        not folded into this total by design."""
+        estimated_pnl = self.estimated_daily_realized_pnl()
+        if estimated_pnl <= self.DAILY_LOSS_LIMIT_QUOTE:
+            logging.warning(
+                "Daily loss limit reached: estimated realized PnL %.4f <= "
+                "limit %.4f — blocking new real autotrade opens for the "
+                "rest of the UTC day",
+                estimated_pnl,
+                self.DAILY_LOSS_LIMIT_QUOTE,
+            )
+            return True
+        return False
+
     def is_margin_available(self, symbol: str) -> bool:
         """
         Check if margin trading is allowed for a symbol
@@ -290,6 +390,12 @@ class AutotradeConsumer:
             logging.info("grid_ladder skipped: missing params or autotrade is false")
             return
         if self._grid_ladder_attempted_recently(params):
+            return
+        if self.daily_loss_limit_reached():
+            logging.warning(
+                "grid_ladder skipped: daily loss limit reached (symbol=%s)",
+                params.symbol,
+            )
             return
 
         symbol = params.symbol
@@ -458,6 +564,13 @@ class AutotradeConsumer:
             if self.reached_max_active_autobots("bots"):
                 logging.info(
                     "Reached maximum number of active bots set in controller settings"
+                )
+            elif self.daily_loss_limit_reached():
+                logging.warning(
+                    "Skipping autotrade: daily loss limit reached "
+                    "(symbol=%s, algorithm=%s)",
+                    symbol,
+                    algorithm_name,
                 )
             elif self._has_active_grid_ladder(symbol, market_type):
                 logging.info(

--- a/strategies/grid/ladder_deployer.py
+++ b/strategies/grid/ladder_deployer.py
@@ -27,6 +27,14 @@ class LadderDeployer:
     MIN_LONG_REGIME_SCORE = 0.45
     MIN_LONG_REGIME_SCORE_RANGE = 0.2
     MIN_ENTRY_CONTRACTS = 2
+    # Two-sided grids on a netted KuCoin futures symbol are safe: the
+    # lifecycle's single-active-side guard (_guard_entry_side /
+    # _cancel_side_entries) already cancels whichever leg doesn't fill
+    # first, so keeping the short leg armed doesn't reintroduce the netting
+    # desync bug. Disabling it instead removes the downside hedge entirely,
+    # which produced worse outcomes than symmetric grids (see incident
+    # 2026-07-22 to 2026-07-26).
+    DISABLE_UPPER_BAND_SHORT_ENTRIES = False
     MIN_BB_WIDTH_STABILITY_CANDLES = 8
     MAX_BB_WIDTH_CHANGE_PCT = 20.0
     ALLOWED_MICRO_REGIMES = ("RANGE", "TRANSITIONAL")
@@ -127,7 +135,7 @@ class LadderDeployer:
             existing_grid_context = {}
         context_payload["grid_ladder"] = {
             **existing_grid_context,
-            "disable_upper_band_short_entries": True,
+            "disable_upper_band_short_entries": self.DISABLE_UPPER_BAND_SHORT_ENTRIES,
             "min_entry_contracts": self.MIN_ENTRY_CONTRACTS,
         }
         settings = self.at_consumer.autotrade_settings
@@ -155,7 +163,7 @@ class LadderDeployer:
                 "bb_low": bb_low,
                 "range_width_pct": range_width_pct,
                 "atr_buffer_pct": breakout_buffer_pct,
-                "disable_upper_band_short_entries": True,
+                "disable_upper_band_short_entries": self.DISABLE_UPPER_BAND_SHORT_ENTRIES,
                 "min_entry_contracts": self.MIN_ENTRY_CONTRACTS,
             },
             allocation_pct=settings.grid_allocation_pct,

--- a/tests/test_autotrade_consumer.py
+++ b/tests/test_autotrade_consumer.py
@@ -13,6 +13,7 @@ from pybinbot import (
     BotBase,
     BotModel,
     BotResponse,
+    DealModel,
     ExchangeId,
     GridDeploymentRequest,
     GridLadderRecord,
@@ -86,6 +87,7 @@ class TestAutotradeConsumer:
         self.mock_binbot_api.get_active_pairs.return_value = []
         self.mock_binbot_api.get_available_fiat.return_value = 1000
         self.mock_binbot_api.get_active_grid_ladders.return_value = []
+        self.mock_binbot_api.get_bots_by_status.return_value = []
         # Methods used in Autotrade (for completeness)
         self.mock_binbot_api.get_single_symbol.return_value = SymbolModel(
             id="BTCUSDT",
@@ -199,6 +201,161 @@ class TestAutotradeConsumer:
 
         self.mock_binbot_api.get_active_pairs.return_value = [1, 2, 3]
         assert self.consumer.reached_max_active_autobots("bots")
+
+    def _closed_bot(
+        self,
+        *,
+        position: Position = Position.long,
+        market_type: MarketType = MarketType.SPOT,
+        pair: str = "SCRUSDTM",
+        opening_price: float,
+        closing_price: float,
+        opening_qty: float,
+        total_commissions: float = 0.0,
+        total_interests: float = 0.0,
+    ) -> BotModel:
+        return BotModel(
+            id=BOT_ID,
+            pair=pair,
+            status=Status.completed,
+            position=position,
+            market_type=market_type,
+            deal=DealModel(
+                opening_price=opening_price,
+                closing_price=closing_price,
+                opening_qty=opening_qty,
+                closing_qty=opening_qty,
+                total_commissions=total_commissions,
+                total_interests=total_interests,
+            ),
+        )
+
+    def test_bot_realized_pnl_quote_matches_known_production_loss(self):
+        # Validated against a real SCRUSDTM futures stop-loss fill: entry
+        # 0.0212, close 0.0206, 583 contracts, 0.00247192 commissions ->
+        # -0.3523. SCRUSDTM's real contract multiplier is 1.0 (mocked
+        # below), matching setup_method's default kucoin_futures_api stub.
+        bot = self._closed_bot(
+            position=Position.long,
+            market_type=MarketType.FUTURES,
+            opening_price=0.0212,
+            closing_price=0.0206,
+            opening_qty=583,
+            total_commissions=0.00247192,
+        )
+        assert self.consumer._bot_realized_pnl_quote(bot) == pytest.approx(
+            -0.3523, abs=1e-4
+        )
+
+    def test_bot_realized_pnl_quote_short_direction_is_inverted(self):
+        bot = self._closed_bot(
+            position=Position.short,
+            opening_price=100.0,
+            closing_price=95.0,
+            opening_qty=1.0,
+        )
+        assert self.consumer._bot_realized_pnl_quote(bot) == pytest.approx(5.0)
+
+    def test_bot_realized_pnl_quote_applies_futures_contract_multiplier(self):
+        # XBTUSDTM's real contract multiplier is 0.001 (1 contract = 0.001
+        # BTC) — without applying it, this would be misstated by 1000x.
+        cast(Any, self.consumer.kucoin_futures_api.get_symbol_info).side_effect = (
+            lambda symbol: SimpleNamespace(
+                multiplier=0.001, lot_size=1, taker_fee_rate=0
+            )
+        )
+        bot = self._closed_bot(
+            market_type=MarketType.FUTURES,
+            pair="XBTUSDTM",
+            opening_price=100_000.0,
+            closing_price=101_000.0,
+            opening_qty=10,
+        )
+        # price delta * qty * multiplier = 1000 * 10 * 0.001 = 10.0
+        assert self.consumer._bot_realized_pnl_quote(bot) == pytest.approx(10.0)
+
+    def test_bot_realized_pnl_quote_spot_bot_skips_multiplier_lookup(self):
+        bot = self._closed_bot(
+            market_type=MarketType.SPOT,
+            opening_price=100.0,
+            closing_price=101.0,
+            opening_qty=1.0,
+        )
+        assert self.consumer._bot_realized_pnl_quote(bot) == pytest.approx(1.0)
+        cast(Any, self.consumer.kucoin_futures_api.get_symbol_info).assert_not_called()
+
+    def test_bot_realized_pnl_quote_excludes_bot_when_multiplier_lookup_fails(self):
+        cast(
+            Any, self.consumer.kucoin_futures_api.get_symbol_info
+        ).side_effect = Exception("boom")
+        bot = self._closed_bot(
+            market_type=MarketType.FUTURES,
+            pair="XBTUSDTM",
+            opening_price=100_000.0,
+            closing_price=90_000.0,
+            opening_qty=10,
+        )
+        assert self.consumer._bot_realized_pnl_quote(bot) == pytest.approx(0.0)
+
+    def test_estimated_daily_realized_pnl_sums_closed_bots(self):
+        self.mock_binbot_api.get_bots_by_status.return_value = [
+            self._closed_bot(opening_price=100.0, closing_price=99.0, opening_qty=1.0),
+            self._closed_bot(opening_price=100.0, closing_price=101.0, opening_qty=1.0),
+        ]
+        assert self.consumer.estimated_daily_realized_pnl() == pytest.approx(0.0)
+
+    def test_daily_loss_limit_not_reached_below_threshold(self):
+        self.mock_binbot_api.get_bots_by_status.return_value = [
+            self._closed_bot(opening_price=100.0, closing_price=99.9, opening_qty=1.0)
+        ]
+        assert not self.consumer.daily_loss_limit_reached()
+
+    def test_daily_loss_limit_reached_past_threshold(self):
+        self.mock_binbot_api.get_bots_by_status.return_value = [
+            self._closed_bot(opening_price=100.0, closing_price=99.0, opening_qty=1.0)
+        ]
+        assert self.consumer.daily_loss_limit_reached()
+
+    @pytest.mark.asyncio
+    async def test_process_autotrade_restrictions_blocks_real_bots_on_daily_loss_limit(
+        self,
+    ):
+        self.mock_binbot_api.get_bots_by_status.return_value = [
+            self._closed_bot(opening_price=100.0, closing_price=90.0, opening_qty=1.0)
+        ]
+        signal = SignalsConsumer(
+            autotrade=True,
+            current_price=100,
+            bot_params=BotBase(
+                pair="BTCUSDT",
+                name="coinrule_buy_the_dip",
+                market_type=MarketType.SPOT,
+                position=Position.long,
+                fiat="USDT",
+                fiat_order_size=25,
+            ),
+        )
+
+        with patch("consumers.autotrade_consumer.Autotrade") as autotrade_cls:
+            await self.consumer.process_autotrade_restrictions(signal)
+
+        autotrade_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_grid_deployment_blocks_on_daily_loss_limit(self):
+        self.mock_binbot_api.get_bots_by_status.return_value = [
+            self._closed_bot(opening_price=100.0, closing_price=90.0, opening_qty=1.0)
+        ]
+        signal = SignalsConsumer(
+            autotrade=True,
+            signal_kind="grid_deploy",
+            grid_params=self._grid_params("BTCUSDT"),
+        )
+
+        await self.consumer.process_autotrade_restrictions(signal)
+
+        self.mock_binbot_api.calculate_grid_levels.assert_not_called()
+        self.mock_binbot_api.create_grid_ladder.assert_not_called()
 
     # --- KlinesProvider test ---
     def test_klines_provider_init(self):

--- a/tests/test_ladder_deployer.py
+++ b/tests/test_ladder_deployer.py
@@ -90,10 +90,10 @@ async def test_ladder_deployer_uses_three_total_levels(
     assert value.grid_params.allocation_pct == 1.0
     assert value.grid_params.cash_reserve_pct == 0.0
     assert value.grid_params.context["grid_ladder"] == {
-        "disable_upper_band_short_entries": True,
+        "disable_upper_band_short_entries": False,
         "min_entry_contracts": 2,
     }
-    assert value.grid_params.indicators["disable_upper_band_short_entries"] is True
+    assert value.grid_params.indicators["disable_upper_band_short_entries"] is False
     assert value.grid_params.indicators["min_entry_contracts"] == 2
 
 


### PR DESCRIPTION
The existing single-active-side guard in binbot's lifecycle already prevents the KuCoin netting-mode desync (cancels the resting opposite leg the instant one side fills), so hardcoding
`disable_upper_band_short_entries=True` was a redundant over-correction that removed the grid's downside hedge entirely and made outcomes worse, not better.

Also add a daily realized-PnL circuit breaker: once today's estimated realized PnL drops to -0.15 USDT or below, block new real bot and grid ladder opens for the rest of the UTC day. Closes the gap where a concurrency-only active-bot cap let completed losers immediately recycle into more real-money trades with no daily downside limit.